### PR TITLE
Safely retrieve localized labels for option set values

### DIFF
--- a/src/Greg.Xrm.ConstantsExtractor/Core/ConstantExtractorManager.cs
+++ b/src/Greg.Xrm.ConstantsExtractor/Core/ConstantExtractorManager.cs
@@ -316,7 +316,7 @@ namespace Greg.Xrm.ConstantsExtractor.Core
 				foreach (OptionMetadata option in options.Options)
 				{
 					var value = option.Value;
-					var label = option.Label.LocalizedLabels.FirstOrDefault()?.Label ?? string.Empty;
+					var label = option.Label.LocalizedLabels.FirstOrDefault()?.Label ?? option.Value.ToString();
 					optionsetValues[value.Value] = label;
 				}
 			}
@@ -335,12 +335,12 @@ namespace Greg.Xrm.ConstantsExtractor.Core
 				var dictionary1 = optionsetValues;
 				int? nullable = trueOption?.Value;
 				int key1 = nullable.Value;
-				string label1 = trueOption.Label.LocalizedLabels.FirstOrDefault()?.Label ?? string.Empty;
+				string label1 = trueOption.Label.LocalizedLabels.FirstOrDefault()?.Label ?? nullable.Value.ToString();
 				dictionary1.Add(key1, label1);
 				Dictionary<int, string> dictionary2 = optionsetValues;
 				nullable = falseOption?.Value;
 				int key2 = nullable.Value;
-				string label2 = falseOption.Label.LocalizedLabels.FirstOrDefault()?.Label ?? string.Empty;
+				string label2 = falseOption.Label.LocalizedLabels.FirstOrDefault()?.Label ?? nullable.Value.ToString();
 				dictionary2.Add(key2, label2);
 			}
 			return optionsetValues;

--- a/src/Greg.Xrm.ConstantsExtractor/Core/ConstantExtractorManager.cs
+++ b/src/Greg.Xrm.ConstantsExtractor/Core/ConstantExtractorManager.cs
@@ -316,7 +316,7 @@ namespace Greg.Xrm.ConstantsExtractor.Core
 				foreach (OptionMetadata option in options.Options)
 				{
 					var value = option.Value;
-					var label = option.Label.LocalizedLabels[0].Label;
+					var label = option.Label.LocalizedLabels.FirstOrDefault()?.Label ?? string.Empty;
 					optionsetValues[value.Value] = label;
 				}
 			}
@@ -335,12 +335,12 @@ namespace Greg.Xrm.ConstantsExtractor.Core
 				var dictionary1 = optionsetValues;
 				int? nullable = trueOption?.Value;
 				int key1 = nullable.Value;
-				string label1 = trueOption.Label.LocalizedLabels[0].Label;
+				string label1 = trueOption.Label.LocalizedLabels.FirstOrDefault()?.Label ?? string.Empty;
 				dictionary1.Add(key1, label1);
 				Dictionary<int, string> dictionary2 = optionsetValues;
 				nullable = falseOption?.Value;
 				int key2 = nullable.Value;
-				string label2 = falseOption.Label.LocalizedLabels[0].Label;
+				string label2 = falseOption.Label.LocalizedLabels.FirstOrDefault()?.Label ?? string.Empty;
 				dictionary2.Add(key2, label2);
 			}
 			return optionsetValues;


### PR DESCRIPTION
This pull request improves the robustness of label extraction in the `GetOptionsetValuesFromMetadata` method by handling cases where `LocalizedLabels` may be empty or missing. Instead of assuming a label is always present, the code now safely retrieves the first label or falls back to using the option value as a string.

Improvements to label extraction:

* Updated label retrieval to use `FirstOrDefault()?.Label ?? option.Value.ToString()` instead of directly accessing the first element, preventing potential exceptions when `LocalizedLabels` is empty. [[1]](diffhunk://#diff-d6cecd4464b4d2948519228142d4b0be685880dfd5ca61fce1d99cfa549d4087L319-R319) [[2]](diffhunk://#diff-d6cecd4464b4d2948519228142d4b0be685880dfd5ca61fce1d99cfa549d4087L338-R343)